### PR TITLE
Addition of assembly statistics

### DIFF
--- a/genotyping-nf/bin/N-positions-replacer.py
+++ b/genotyping-nf/bin/N-positions-replacer.py
@@ -1,0 +1,28 @@
+import sys
+import pandas as pd
+import argparse
+from Bio import SeqIO
+from Bio.Seq import Seq
+
+parser = argparse.ArgumentParser(description="Replace positions with coverage below 20 with 'N' in a FASTA sequence.")
+parser.add_argument("--fasta", required=True, help="Path to the input FASTA file.")
+parser.add_argument("--coverage", required=True, help="Path to the coverage CSV file.")
+args = parser.parse_args()
+
+coverage_file = pd.read_csv(args.coverage, sep=";")
+
+fasta_records = SeqIO.to_dict(SeqIO.parse(args.fasta, "fasta"))
+
+# Process each sequence in the FASTA file
+for ref, record in fasta_records.items():
+    sequence = list(str(record.seq))
+    ref_coverage = coverage_file[coverage_file["ref"] == ref]
+    # Replace positions with coverage below 20 with "N"
+    for _, row in ref_coverage.iterrows():
+        if int(row["depth"]) < 20:
+            sequence[int(row["pos"]) - 1] = "N"
+    record.seq = Seq("".join(sequence))
+
+# Write the modified sequences back to the FASTA file
+with open(args.fasta, "w") as outfile:
+    SeqIO.write(fasta_records.values(), outfile, "fasta")

--- a/genotyping-nf/bin/quality-metrics.py
+++ b/genotyping-nf/bin/quality-metrics.py
@@ -1,0 +1,22 @@
+import csv
+from Bio import SeqIO
+import argparse
+
+# Argument parser
+parser = argparse.ArgumentParser(description="Calculate sequence length and percentage of Ns in a multi-FASTA file and append results to a CSV file.")
+parser.add_argument("--fasta", required=True, help="Path to the input FASTA file.")
+parser.add_argument("--csv", required=True, help="Path to the existing CSV file to append results.")
+args = parser.parse_args()
+
+# Open the CSV file in append mode
+with open(args.csv, "a", newline="") as csvfile:
+    writer = csv.writer(csvfile, delimiter=";")
+    
+    # Process each sequence in the FASTA file
+    for record in SeqIO.parse(args.fasta, "fasta"):
+        seq_length = len(record.seq)
+        n_count = record.seq.upper().count("N")
+        percentage_n = (n_count / seq_length) * 100
+        # Write the results to the CSV file
+        writer.writerow([f"{record.id}_length", seq_length])
+        writer.writerow([f"{record.id}_percentageN", f"{percentage_n:.2f}%"])

--- a/genotyping-nf/enterovirus-genotyping.nf
+++ b/genotyping-nf/enterovirus-genotyping.nf
@@ -3,7 +3,7 @@
 nextflow.enable.dsl = 2
 
 include { CREATEDIR; QUALCONTROL; FILTHOST; TRIMPRIMERSR; TRIMPRIMERSL; GETEVREADS } from './modules/quality-control'
-include { SPADES                                                                   } from './modules/assembly'
+include { SPADES; NREPLACER; ASSEMBLYMETRICS                                                                   } from './modules/assembly'
 include { BLASTN; GETBLASTNMATCH; GETCDS; DIAMOND; GENOTYPEVP1                     } from './modules/genotyping'
 
 // Checking user-defined parameters
@@ -87,5 +87,12 @@ workflow {
     vp1_ch = GENOTYPEVP1(prot_match_ch)
     if (params.input == "fastq") {
     	ev_ch = GETEVREADS(spades_input_ch, get_match_ch)
-    }
+        nreplaced_ch = NREPLACER(spades_input_ch, get_match_ch)
+        assembly_ch = ASSEMBLYMETRICS(nreplaced_ch)
+    } 
+    //else { // TO DO: Integrarlo con el formato de entrada FASTA.
+    // se le debe dar de input el directorio donde este el análisis, ya que va a buscar
+    // el archivo ${dirSample}/results/ev-match.fasta
+        // assembly_ch = ASSEMBLYMETRICS([params.dirFasta])
+    //}
 }

--- a/genotyping-nf/enterovirus-genotyping.nf
+++ b/genotyping-nf/enterovirus-genotyping.nf
@@ -3,7 +3,7 @@
 nextflow.enable.dsl = 2
 
 include { CREATEDIR; QUALCONTROL; FILTHOST; TRIMPRIMERSR; TRIMPRIMERSL; GETEVREADS } from './modules/quality-control'
-include { SPADES; NREPLACER; ASSEMBLYMETRICS                                                                   } from './modules/assembly'
+include { SPADES; NREPLACER; ASSEMBLYMETRICS                                       } from './modules/assembly'
 include { BLASTN; GETBLASTNMATCH; GETCDS; DIAMOND; GENOTYPEVP1                     } from './modules/genotyping'
 
 // Checking user-defined parameters


### PR DESCRIPTION
**Summary of Changes**

This pull request introduces the following updates and improvements:

- Unified read count in `quality-control.nf`: Standardized the read count output to provide a single, unified value across the workflow.
- New process NREPLACER in `assembly.nf`: Replaces positions with coverage below 20x with 'N' characters to improve downstream analyses and sequence reliability.
- New process ASSEMBLYMETRICS in `assembly.nf`: Calculates the total sequence length and the percentage of 'N' bases (%N) for both assembled sequences and user-provided FASTA files.
- Updated `enterovirus-genotyping.nf`: Integrated the new NREPLACER and ASSEMBLYMETRICS processes into the genotyping pipeline.

**TODO:** Integration of ASSEMBLYMETRICS for user-provided FASTA files is pending. A placeholder comment has been added to enterovirus-genotyping.nf for future implementation.